### PR TITLE
Update MIT cert styling

### DIFF
--- a/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-ltr.css
+++ b/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-ltr.css
@@ -522,18 +522,18 @@ body {
 .wrapper-accomplishment-org .organization-logo {
   display: block;
   margin: 0 auto 1.25rem;
-  width: 65.95745%;
+  width: 14.89362%;
 }
 
 @media (min-width:480px) {
   .wrapper-accomplishment-org .organization-logo {
-    width: 31.91489%;
+    width: 14.89362%;
   }
 }
 
 @media (min-width:768px) {
   .wrapper-accomplishment-org .organization-logo {
-    width: 31.91489%;
+    width: 14.89362%;
   }
 }
 
@@ -565,7 +565,7 @@ body {
 
 @media (min-width:768px) {
   .accomplishment-statement .accomplishment-logo {
-    max-width: 15%;
+    max-width: 18%;
   }
 }
 
@@ -767,7 +767,7 @@ body {
 
   .wrapper-accomplishment-org .organization-logo {
     display: block;
-    width: 23.40426%;
+    width: 14.89362%;
     font-weight: 600;
   }
 
@@ -809,7 +809,7 @@ body {
   }
 
   .accomplishment-statement .accomplishment-logo {
-    max-width: 15%!important;
+    max-width: 25%!important;
   }
 
   .signatory {

--- a/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-rtl.css
+++ b/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-rtl.css
@@ -522,18 +522,18 @@ body {
 .wrapper-accomplishment-org .organization-logo {
   display: block;
   margin: 0 auto 1.25rem;
-  width: 65.95745%;
+  width: 14.89362%;
 }
 
 @media (min-width:480px) {
   .wrapper-accomplishment-org .organization-logo {
-    width: 31.91489%;
+    width: 14.89362%;
   }
 }
 
 @media (min-width:768px) {
   .wrapper-accomplishment-org .organization-logo {
-    width: 31.91489%;
+    width: 14.89362%;
   }
 }
 
@@ -565,7 +565,7 @@ body {
 
 @media (min-width:768px) {
   .accomplishment-statement .accomplishment-logo {
-    max-width: 15%;
+    max-width: 18%;
   }
 }
 
@@ -767,7 +767,7 @@ body {
 
   .wrapper-accomplishment-org .organization-logo {
     display: block;
-    width: 23.40426%;
+    width: 14.89362%;
     font-weight: 600;
   }
 
@@ -809,7 +809,7 @@ body {
   }
 
   .accomplishment-statement .accomplishment-logo {
-    max-width: 15%!important;
+    max-width: 25%!important;
   }
 
   .signatory {

--- a/edx_credentials_themes/static/mitpe/sass/_layouts-rendering.scss
+++ b/edx_credentials_themes/static/mitpe/sass/_layouts-rendering.scss
@@ -43,14 +43,14 @@
   .organization-logo {
     display: block;
     margin: 0 auto spacing-vertical(small) auto;
-    width: span(8 of 12);
+    width: span(2 of 12);
 
     @include susy-breakpoint($bp-screen-sm, $susy) {
-      width: span(4 of 12);
+      width: span(2 of 12);
     }
 
     @include susy-breakpoint($bp-screen-md, $susy) {
-      width: span(4 of 12);
+      width: span(2 of 12);
     }
   }
 
@@ -82,7 +82,7 @@
     }
 
     @include susy-breakpoint($bp-screen-md, $susy) {
-        max-width: 15%;
+        max-width: 18%;
     }
   }
 

--- a/edx_credentials_themes/static/mitpe/sass/_print-rendering.scss
+++ b/edx_credentials_themes/static/mitpe/sass/_print-rendering.scss
@@ -77,7 +77,7 @@
 
       .organization-logo {
         display: block;
-        width: span(3 of 12);
+        width: span(2 of 12);
         font-weight: $headings-font-weight-bold;
       }
     }
@@ -118,7 +118,7 @@
         }
 
         .accomplishment-logo {
-          max-width: 15% !important;
+          max-width: 25% !important;
         }
     }
 

--- a/edx_credentials_themes/templates/mitpe/credentials/programs/base.html
+++ b/edx_credentials_themes/templates/mitpe/credentials/programs/base.html
@@ -57,7 +57,8 @@
               <h4 class="signatory-name">{{ signatory.name }}</h4>
               <p class="signatory-credentials">
                 {% autoescape off %}
-                <span class="role">{{ signatory.title }}, </span>
+                <span class="role">{{ signatory.title }}</span>
+                <br>
                 <span class="organization">
                     {% firstof signatory.organization_name_override program_details.organizations.0.name %}
                   </span>


### PR DESCRIPTION
MIT requested some changes regarding design of their cert. This changes the org logo size, the seal size, and breaks the signatory title onto two lines.

[WL-1164]