### PR TITLE
Allow override of program title.

### DIFF
--- a/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-ltr.css
+++ b/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-ltr.css
@@ -64,7 +64,7 @@
   display: table;
 }
 
-.list .item:last-child,.list:last-child,.list li:last-child,ul .item:last-child,ul:last-child,ul li:last-child {
+.list .item-complex:last-child,.list .item:last-child,.list:last-child,.list li:last-child,ul .item-complex:last-child,ul .item:last-child,ul:last-child,ul li:last-child {
   margin-bottom: 0;
   padding-bottom: 0;
   border-bottom: none;
@@ -300,6 +300,10 @@ h6 {
 
 .list,ul {
   margin-bottom: 1.875rem;
+}
+
+.list .item-complex,ul .item-complex {
+  margin-bottom: 1.25rem;
 }
 
 .list .item-copy,ul .item-copy {

--- a/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-rtl.css
+++ b/edx_credentials_themes/static/mitpe/css/mitpe.certificate.style-rtl.css
@@ -64,7 +64,7 @@
   display: table;
 }
 
-.list .item:last-child,.list:last-child,.list li:last-child,ul .item:last-child,ul:last-child,ul li:last-child {
+.list .item-complex:last-child,.list .item:last-child,.list:last-child,.list li:last-child,ul .item-complex:last-child,ul .item:last-child,ul:last-child,ul li:last-child {
   margin-bottom: 0;
   padding-bottom: 0;
   border-bottom: none;
@@ -300,6 +300,10 @@ h6 {
 
 .list,ul {
   margin-bottom: 1.875rem;
+}
+
+.list .item-complex,ul .item-complex {
+  margin-bottom: 1.25rem;
 }
 
 .list .item-copy,ul .item-copy {

--- a/edx_credentials_themes/templates/mitpe/credentials/programs/base.html
+++ b/edx_credentials_themes/templates/mitpe/credentials/programs/base.html
@@ -34,7 +34,7 @@
 
             <span class="accomplishment-course">
                 <span
-                    class="accomplishment-course-name">{{ program_details.title }}</span>
+                    class="accomplishment-course-name">{% block program_title %} {{ program_details.title }} {% endblock %}</span>
                 <span class="accomplishment-program-type">PROFESSIONAL CERTIFICATE PROGRAM</span>
                 <span class="sr-only">{% trans "held during" %}</span>
                 <span class="accomplishment-course-dates"> 

--- a/edx_credentials_themes/templates/mitpe/credentials/programs/c8f689f4-8418-41bd-a73b-64c1459c1bb2/certificate.html
+++ b/edx_credentials_themes/templates/mitpe/credentials/programs/c8f689f4-8418-41bd-a73b-64c1459c1bb2/certificate.html
@@ -1,5 +1,7 @@
 {% extends "../base.html" %}
 {% load staticfiles %}
+
+{% block program_title %} Architecture and Systems Engineering: Models and Methods to Manage Complex Systems {% endblock %}
 {% block start_date %}March 20, 2017{% endblock %}
 {% block end_date %}August 7, 2017{% endblock %}
 {% block credit_amount %}8.5{% endblock %}

--- a/edx_credentials_themes/templates/mitpe/credentials/programs/d670134d-3155-4b8a-b058-4618bb2b3e2c/certificate.html
+++ b/edx_credentials_themes/templates/mitpe/credentials/programs/d670134d-3155-4b8a-b058-4618bb2b3e2c/certificate.html
@@ -1,6 +1,7 @@
 {% extends "../base.html" %}
 {% load staticfiles %}
 
+{% block program_title %} Architecture and Systems Engineering: Models and Methods to Manage Complex Systems {% endblock %}
 {% block start_date %}March 20, 2017{% endblock %}
 {% block end_date %}August 7, 2017{% endblock %}
 {% block credit_amount %}8.5{% endblock %}


### PR DESCRIPTION
Titles longer than 42 chars are split into title and subtitle for
formatting purposes. Currently subtitle is not passed into the template
content, so for the time being program titles must be overriden in
order for the certificate to display the correct title.

This will be fixed once WL-1120 is complete and subtitle can be added
to the context.