### PR TITLE
MICROBA-646 Fix travis config warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: false
-
 language: python
+os: linux
+dist: focal
 
 python:
   - 3.8


### PR DESCRIPTION
Fixing warnings from travis config (ex. https://travis-ci.com/github/edx/credentials-themes/jobs/429157893/config)
Values taken from credentials: https://github.com/edx/credentials/blob/master/.travis.yml