### PR TITLE
build: Add codeowners file to help with PR notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @edx/edx-aperture


### PR DESCRIPTION
Add codeowners file to help with PR notifications.

Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

MICROBA-977